### PR TITLE
Fix Mac bug

### DIFF
--- a/common/wirelessredstone/proxy/WRCommonProxy.java
+++ b/common/wirelessredstone/proxy/WRCommonProxy.java
@@ -46,7 +46,7 @@ public class WRCommonProxy implements ICommonProxy {
 	@Override
 	public String getMinecraftDir() {
 		// TODO Auto-generated method stub
-		return ".";
+		return Minecraft.getMinecraftDir().toString();
 	}
 
 	@Override


### PR DESCRIPTION
When you use this mod on a Mac, it writes the log to /Applications, and not the minecraft directory. This pull should fix it.
